### PR TITLE
Selector error

### DIFF
--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -27,7 +27,6 @@ export class Counter extends React.Component {
 }
 
 let cnt = 1
-
 export default connect(state$, state => (console.log(`observerNext: ${cnt++} `, state, ), {
   counter: state.counter && state.counter.counter,
   // increment(n) { CounterActions.increment$.next(n) },

--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -12,6 +12,7 @@ export class Counter extends React.Component {
   };
 
   render() {
+    console.log('render');
     return (
       <div className="counter">
         <h1 className="counter__title">{ this.props.counter }</h1>
@@ -25,8 +26,10 @@ export class Counter extends React.Component {
   }
 }
 
-export default connect(state$, state => ({
-  counter: state.counter,
+let cnt = 1
+
+export default connect(state$, state => (console.log(`observerNext: ${cnt++} `, state, ), {
+  counter: state.counter && state.counter.counter,
   // increment(n) { CounterActions.increment$.next(n) },
   // decrement(n) { CounterActions.decrement$.next(n) }
   increment: bindAction(CounterActions.increment$),

--- a/src/reducers/CounterReducer.js
+++ b/src/reducers/CounterReducer.js
@@ -1,12 +1,18 @@
 import Rx from "rxjs";
 import CounterActions from "app/actions/CounterActions";
 
+const initialState = {
+  counter: 1
+}
+
 const CounterReducer$ = Rx.Observable.merge(
   CounterActions.increment$.map((n = 1) =>
     state => ({ ...state, counter: state.counter+n })),
 
   CounterActions.decrement$.map((n = 1) =>
     state => ({ ...state, counter: state.counter-n }))
-);
+)
+.startWith(() => initialState)
+
 
 export default CounterReducer$;

--- a/src/rx-state/connect.js
+++ b/src/rx-state/connect.js
@@ -12,6 +12,7 @@ function connect(state$, selector = (state) => state) {
       }
 
       render() {
+        console.log('renderConnect');
         return (
           <WrappedComponent {...this.state} {...this.props} />
         );

--- a/src/rx-state/connect.js
+++ b/src/rx-state/connect.js
@@ -12,7 +12,7 @@ function connect(state$, selector = (state) => state) {
       }
 
       render() {
-        console.log('renderConnect');
+        console.log('renderConnectec');
         return (
           <WrappedComponent {...this.state} {...this.props} />
         );

--- a/src/rx-state/createState.js
+++ b/src/rx-state/createState.js
@@ -3,9 +3,9 @@ import Rx from "rxjs";
 function createState(reducer$, initialState$ = Rx.Observable.of({})) {
   return initialState$
     .merge(reducer$)
-    .scan((state, reducer) => reducer(state))
+    .scan((state, [scope, reducer]) => ({ ...state, [scope]: reducer(state[scope]) }))
     .publishReplay(1)
-    .refCount();
+    .refCount()
 }
 
 export default createState;

--- a/src/state.js
+++ b/src/state.js
@@ -1,11 +1,16 @@
+// state.js
 import Rx from "rxjs";
 import createState from "app/rx-state/createState";
 import CounterReducer$ from "app/reducers/CounterReducer";
+import CounterReducer0$ from "app/reducers/CounterReducer0";
 
+// "counter" and "otherCounter" are like mounting points of the reducer
+// can be easily turn into combineReducers
 const reducer$ = Rx.Observable.merge(
-  CounterReducer$
+  CounterReducer$.map(reducer => ["counter", reducer]),
+  CounterReducer0$.map(reducer => ["otherCounter", reducer]),
 );
 
-const initialState$ = Rx.Observable.of({ counter: 0 });
+let initialState$
 
 export default createState(reducer$, initialState$);


### PR DESCRIPTION
``` js
// observerNext: 1  Object {}
// observerNext: 2  Object {counter: Object}
// observerNext: 3  Object {counter: Object, otherCounter: Object}
export default connect(state$, state => (console.log(`observerNext: ${cnt++} `, state, ), {
  //counter: state.counter && state.counter.counter,
  counter: state.counter.counter, // will be error - Cannot read property 'counter' of undefined
...
}))(Counter);
```
